### PR TITLE
Feat: added specific user agent for sandbox transactions

### DIFF
--- a/Controller/Callback.php
+++ b/Controller/Callback.php
@@ -1,8 +1,6 @@
 <?php
+
 /**
- *
- *
- *
  * @category    Koin
  * @package     Koin_Payment
  */

--- a/Controller/Callback/Payments.php
+++ b/Controller/Callback/Payments.php
@@ -1,8 +1,6 @@
 <?php
+
 /**
- *
- *
- *
  * @category    Koin
  * @package     Koin_Payment
  */
@@ -29,7 +27,7 @@ class Payments extends Callback
     public function validateForCsrf(RequestInterface $request): ?bool
     {
         $hash = $request->getParam('hash');
-        $storeHash = sha1($this->helperData->getGeneralConfig('private_key'));
+        $storeHash = $this->helperData->getHash();
         return ($hash == $storeHash);
     }
 

--- a/Controller/Request/Save.php
+++ b/Controller/Request/Save.php
@@ -1,0 +1,87 @@
+<?php
+
+/**
+ *
+ *
+ *
+ *
+ *
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade this extension to newer
+ * version in the future.
+ *
+ * @category    Koin
+ * @package     Koin_Payment
+ *
+ *
+ */
+
+namespace Koin\Payment\Controller\Request;
+
+use Koin\Payment\Helper\Data;
+use Magento\Framework\App\Action\Action;
+use Magento\Backend\App\Action\Context;
+use Magento\Framework\App\CsrfAwareActionInterface;
+use Magento\Framework\App\Request\InvalidRequestException;
+use Magento\Framework\App\RequestInterface;
+use Magento\Framework\Controller\ResultFactory;
+
+class Save extends Action implements CsrfAwareActionInterface
+{
+    /** @var Data */
+    protected $helperData;
+
+    public function __construct(
+        Context $context,
+        Data $helperData
+    ) {
+        $this->helperData = $helperData;
+
+        parent::__construct($context);
+    }
+
+    public function execute()
+    {
+        $statusCode = 500;
+        try {
+            $content = $this->helperData->jsonDecode($this->getRequest()->getContent());
+            $this->helperData->saveRequest(
+                $content['request'],
+                $content['response'],
+                $content['status_code'],
+                $content['method']
+            );
+            $statusCode = 204;
+        } catch (\Exception $e) {
+            $this->helperData->log($e->getMessage());
+        }
+
+        $result = $this->resultFactory->create(ResultFactory::TYPE_RAW);
+        $result->setHttpResponseCode($statusCode);
+        return $result;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function createCsrfValidationException(RequestInterface $request): ?InvalidRequestException
+    {
+        $result = $this->resultFactory->create(ResultFactory::TYPE_RAW);
+        $result->setHttpResponseCode(403);
+        return new InvalidRequestException(
+            $result
+        );
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function validateForCsrf(RequestInterface $request): ?bool
+    {
+        $hash = $request->getParam('hash');
+        $storeHash = $this->helperData->getHash(Data::REQUEST_SALT);
+        return ($hash == $storeHash);
+    }
+}

--- a/Gateway/Http/Client.php
+++ b/Gateway/Http/Client.php
@@ -86,11 +86,18 @@ class Client
     {
         $privateKey = $this->helper->getGeneralConfig('private_key', $storeId);
 
-        return [
+        $headers = [
             'Content-Type' => 'application/json',
             'Authorization' => 'Bearer ' . $this->encryptor->decrypt($privateKey),
             'X-Module-Version' => $this->helper->getModuleVersion()
         ];
+
+        if ($this->helper->getGeneralConfig('use_sandbox')) {
+            $headers['User-Agent'] = 'koin-oficial';
+        }
+
+
+        return $headers;
     }
 
     /**

--- a/Gateway/Http/Client/Payments/Api.php
+++ b/Gateway/Http/Client/Payments/Api.php
@@ -148,8 +148,14 @@ class Api
         $request,
         $response,
         $statusCode,
-        $method = \Koin\Payment\Model\Ui\Pix\ConfigProvider::CODE
+        $method = \Koin\Payment\Model\Ui\Pix\ConfigProvider::CODE,
+        $async = false
     ): void {
+        if ($async) {
+            $this->helper->saveRequestAsync($request, $response, $statusCode, $method);
+            return;
+        }
+
         $this->helper->saveRequest($request, $response, $statusCode, $method);
     }
 }

--- a/Gateway/Http/Client/Payments/Api/Notification.php
+++ b/Gateway/Http/Client/Payments/Api/Notification.php
@@ -50,7 +50,11 @@ class Notification extends Client
         $response = $api->send();
         $content = $response->getBody();
         if ($content && $response->getStatusCode() != 204) {
-            $content = $this->json->unserialize($content);
+            try {
+                $content = $this->json->unserialize($content);
+            } catch (\Exception $e) {
+                $content = (string) $response->getBody();
+            }
         }
 
         return [

--- a/Gateway/Http/Client/Payments/Refund.php
+++ b/Gateway/Http/Client/Payments/Refund.php
@@ -64,12 +64,15 @@ class Refund implements ClientInterface
 
         $statusCode = $transaction['status'] ?? null;
         $status = $transaction['response']['status'] ?? $statusCode;
+        $statusType = is_array($status) && isset($status['type']) ? $status['type'] : null;
+        $async = $statusType === Api::STATUS_FAILED || $statusCode >= 300;
 
         $this->api->saveRequest(
             $requestBody,
             $transaction['response'],
             $statusCode,
-            self::LOG_NAME
+            self::LOG_NAME,
+            $async
         );
 
         return ['status' => $status, 'status_code' => $statusCode, 'transaction' => $transaction['response']];

--- a/Gateway/Http/Client/Risk/Api/Evaluation.php
+++ b/Gateway/Http/Client/Risk/Api/Evaluation.php
@@ -40,7 +40,11 @@ class Evaluation extends Client
         $response = $api->send();
         $content = $response->getBody();
         if ($content && $response->getStatusCode() != 204) {
-            $content = $this->json->unserialize($content);
+            try {
+                $content = $this->json->unserialize($content);
+            } catch (\Exception $e) {
+                $content = (string) $response->getBody();
+            }
         }
 
         return [
@@ -64,7 +68,11 @@ class Evaluation extends Client
         $response = $api->send();
         $content = $response->getBody();
         if ($content && $response->getStatusCode() != 204) {
-            $content = $this->json->unserialize($content);
+            try {
+                $content = $this->json->unserialize($content);
+            } catch (\Exception $e) {
+                $content = (string) $response->getBody();
+            }
         }
 
         return [
@@ -88,7 +96,11 @@ class Evaluation extends Client
         $response = $api->send();
         $content = $response->getBody();
         if ($content && $response->getStatusCode() != 204) {
-            $content = $this->json->unserialize($content);
+            try {
+                $content = $this->json->unserialize($content);
+            } catch (\Exception $e) {
+                $content = (string) $response->getBody();
+            }
         }
 
         return [
@@ -115,7 +127,11 @@ class Evaluation extends Client
         $response = $api->send();
         $content = $response->getBody();
         if ($content && $response->getStatusCode() != 204) {
-            $content = $this->json->unserialize($content);
+            try {
+                $content = $this->json->unserialize($content);
+            } catch (\Exception $e) {
+                $content = (string) $response->getBody();
+            }
         }
 
         return [

--- a/README.md
+++ b/README.md
@@ -266,4 +266,6 @@ v2.5.9:
 v2.6.0
 - Feat: Added new options for installment rules to show only the text or the text with the installments
 - Feat: Possibility to show more than one installment rules with the same installment number
+- Fix: fallback to use payments URL for tokenize
+- Fix: error when creating a refund that was dispatching an error even when the refund was successful
 

--- a/README.md
+++ b/README.md
@@ -269,3 +269,6 @@ v2.6.0
 - Fix: fallback to use payments URL for tokenize
 - Fix: error when creating a refund that was dispatching an error even when the refund was successful
 
+v2.6.1
+- Feat: Save Refund request and response when order transaction rollbacks
+- Feat: add specific user agent for sandbox transactions

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "koin/payment",
     "description": "Koin Payment Method for Magento 2.3.5+",
     "type": "magento2-module",
-    "version": "2.6.0",
+    "version": "2.6.1",
     "license": [
         "OSL-3.0",
         "AFL-3.0"

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -13,7 +13,7 @@
  */
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Koin_Payment" setup_version="2.6.0">
+    <module name="Koin_Payment" setup_version="2.6.1">
         <sequence>
             <module name="Magento_Sales"/>
             <module name="Magento_Payment"/>


### PR DESCRIPTION
**Title:**
Added specific user agent for sandbox transactions

**Description:**
* It was requested to add a specific user agent for sandbox transactions, and when a refund transaction failed, Magento rollback all;

**Checklist:**
- [x] Changes are consistent with the project's coding style.
- [x] Documentation (if applicable) has been updated.
- [x] Link to related issue (if applicable):

**Testing Instructions:**
* It's necessary to make a new transaction in sandbox environment, the user agent must be 'koin-oficial'
* To test the refund error, create a new credit memo and when it returns failed, it must have saved on Requests and Responses.
