### PR TITLE
Fix: save async request when different store code

### DIFF
--- a/Controller/Request/Save.php
+++ b/Controller/Request/Save.php
@@ -81,7 +81,7 @@ class Save extends Action implements CsrfAwareActionInterface
     public function validateForCsrf(RequestInterface $request): ?bool
     {
         $hash = $request->getParam('hash');
-        $storeHash = sha1(Data::REQUEST_SALT);
+        $storeHash = sha1($this->helperData->getHash(0) . DATA::REQUEST_SALT);
         return ($hash == $storeHash);
     }
 }

--- a/Controller/Request/Save.php
+++ b/Controller/Request/Save.php
@@ -81,7 +81,7 @@ class Save extends Action implements CsrfAwareActionInterface
     public function validateForCsrf(RequestInterface $request): ?bool
     {
         $hash = $request->getParam('hash');
-        $storeHash = $this->helperData->getHash(Data::REQUEST_SALT);
+        $storeHash = sha1(Data::REQUEST_SALT);
         return ($hash == $storeHash);
     }
 }

--- a/Gateway/Http/Client.php
+++ b/Gateway/Http/Client.php
@@ -86,11 +86,18 @@ class Client
     {
         $privateKey = $this->helper->getGeneralConfig('private_key', $storeId);
 
-        return [
+        $headers = [
             'Content-Type' => 'application/json',
             'Authorization' => 'Bearer ' . $this->encryptor->decrypt($privateKey),
             'X-Module-Version' => $this->helper->getModuleVersion()
         ];
+
+        if ($this->helper->getGeneralConfig('use_sandbox')) {
+            $headers['User-Agent'] = 'koin-oficial';
+        }
+
+
+        return $headers;
     }
 
     /**

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -289,7 +289,7 @@ class Data extends \Magento\Payment\Helper\Data
             try {
                 $url = $this->_getUrl(
                     'koin/request/save',
-                    ['_query' => ['hash' => sha1(self::REQUEST_SALT)]]
+                    ['_query' => ['hash' => sha1($this->getHash(0) . self::REQUEST_SALT)]]
                 );
                 $client = new HttpClient();
                 $client->setUri($url);
@@ -359,7 +359,7 @@ class Data extends \Magento\Payment\Helper\Data
         return $this->storeManager->getStore($orderId)->getUrl(
             'koin/callback/payments',
             [
-                '_query' => ['hash' => $this->getHash($order->getStoreId())],
+                '_query' => ['hash' => $this->getHash(0)],
                 '_secure' => true
             ]
         );

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -289,7 +289,7 @@ class Data extends \Magento\Payment\Helper\Data
             try {
                 $url = $this->_getUrl(
                     'koin/request/save',
-                    ['_query' => ['hash' => $this->getHash(self::REQUEST_SALT)]]
+                    ['_query' => ['hash' => sha1(self::REQUEST_SALT)]]
                 );
                 $client = new HttpClient();
                 $client->setUri($url);
@@ -359,15 +359,15 @@ class Data extends \Magento\Payment\Helper\Data
         return $this->storeManager->getStore($orderId)->getUrl(
             'koin/callback/payments',
             [
-                '_query' => ['hash' => $this->getHash()],
+                '_query' => ['hash' => $this->getHash($order->getStoreId())],
                 '_secure' => true
             ]
         );
     }
 
-    public function getHash(string $salt = ''): string
+    public function getHash($scopeCode = null): string
     {
-        return sha1($this->getGeneralConfig('private_key') . $salt);
+        return sha1($this->getGeneralConfig('private_key', $scopeCode));
     }
 
     public function getAntifraudCallbackUrl(Order $order): string

--- a/README.md
+++ b/README.md
@@ -269,3 +269,6 @@ v2.6.0
 - Fix: fallback to use payments URL for tokenize
 - Fix: error when creating a refund that was dispatching an error even when the refund was successful
 
+v2.6.1
+- Feat: Save Refund request and response when order transaction rollbacks
+- Feat: add specific user agent for sandbox transactions

--- a/README.md
+++ b/README.md
@@ -272,3 +272,6 @@ v2.6.0
 v2.6.1
 - Feat: Save Refund request and response when order transaction rollbacks
 - Feat: add specific user agent for sandbox transactions
+
+v2.6.2
+- Feat: Use default private key async requests

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "koin/payment",
     "description": "Koin Payment Method for Magento 2.3.5+",
     "type": "magento2-module",
-    "version": "2.6.1",
+    "version": "2.6.2",
     "license": [
         "OSL-3.0",
         "AFL-3.0"

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -13,7 +13,7 @@
  */
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Koin_Payment" setup_version="2.6.1">
+    <module name="Koin_Payment" setup_version="2.6.2">
         <sequence>
             <module name="Magento_Sales"/>
             <module name="Magento_Payment"/>


### PR DESCRIPTION
**Title:**
Fix: save async request when different store code

**Description:**
* There was a problem that, when the store has different store code, and the request is saved async, the hash was diverging

**Checklist:**
- [x] Changes are consistent with the project's coding style.
- [x] Documentation (if applicable) has been updated.
- [x] Link to related issue (if applicable):

**Testing Instructions:**
* Try to create a refund that returns Failed, with a different private key on default and store view
