### PR TITLE
Fix: save request failed to offline transactions

### DIFF
--- a/Controller/Request/Save.php
+++ b/Controller/Request/Save.php
@@ -81,7 +81,7 @@ class Save extends Action implements CsrfAwareActionInterface
     public function validateForCsrf(RequestInterface $request): ?bool
     {
         $hash = $request->getParam('hash');
-        $storeHash = sha1(DATA::REQUEST_SALT);
+        $storeHash = sha1($this->helperData->getHash(0) . DATA::REQUEST_SALT);
         return ($hash == $storeHash);
     }
 }

--- a/Controller/Request/Save.php
+++ b/Controller/Request/Save.php
@@ -81,7 +81,7 @@ class Save extends Action implements CsrfAwareActionInterface
     public function validateForCsrf(RequestInterface $request): ?bool
     {
         $hash = $request->getParam('hash');
-        $storeHash = sha1($this->helperData->getHash(0) . DATA::REQUEST_SALT);
+        $storeHash = sha1(DATA::REQUEST_SALT);
         return ($hash == $storeHash);
     }
 }

--- a/Gateway/Http/Client/Payments/Api/Refund.php
+++ b/Gateway/Http/Client/Payments/Api/Refund.php
@@ -21,7 +21,7 @@ class Refund extends Client
     public const CANCEL_STATUS = ['Opened', 'Authorized', 'Published'];
 
     /**
-     * @param array $data
+     * @param array|\stdClass $data
      * @param string $orderId
      * @param string $status
      * @param int $storeId

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -290,7 +290,7 @@ class Data extends \Magento\Payment\Helper\Data
                 $storeId = $this->storeManager->getDefaultStoreView()->getStoreId();
                 $url = $this->storeManager->getStore($storeId)->getUrl(
                     'koin/request/save',
-                    ['_query' => ['hash' => sha1($this->getHash(0) . self::REQUEST_SALT)]]
+                    ['_query' => ['hash' => sha1(self::REQUEST_SALT)]]
                 );
 
                 $client = new HttpClient();

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -291,7 +291,7 @@ class Data extends \Magento\Payment\Helper\Data
                     'koin/request/save',
                     ['hash' => sha1($this->getHash(0) . self::REQUEST_SALT)]
                 );
-
+                $this->log($url);
                 $client = new HttpClient();
                 $client->setUri($url);
                 $client->setMethod(Request::METHOD_POST);

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -287,10 +287,9 @@ class Data extends \Magento\Payment\Helper\Data
     {
         if ($this->getGeneralConfig('debug')) {
             try {
-                $storeId = $this->storeManager->getDefaultStoreView()->getStoreId();
                 $url = $this->_urlBuilder->getRouteUrl(
                     'koin/request/save',
-                    ['hash' => sha1(self::REQUEST_SALT)]
+                    ['hash' => sha1($this->getHash(0) . self::REQUEST_SALT)]
                 );
 
                 $client = new HttpClient();

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -288,9 +288,9 @@ class Data extends \Magento\Payment\Helper\Data
         if ($this->getGeneralConfig('debug')) {
             try {
                 $storeId = $this->storeManager->getDefaultStoreView()->getStoreId();
-                $url = $this->storeManager->getStore($storeId)->getUrl(
+                $url = $this->_urlBuilder->getRouteUrl(
                     'koin/request/save',
-                    ['_query' => ['hash' => sha1(self::REQUEST_SALT)]]
+                    ['hash' => sha1(self::REQUEST_SALT)]
                 );
 
                 $client = new HttpClient();

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -287,10 +287,12 @@ class Data extends \Magento\Payment\Helper\Data
     {
         if ($this->getGeneralConfig('debug')) {
             try {
-                $url = $this->_getUrl(
+                $storeId = $this->storeManager->getDefaultStoreView()->getStoreId();
+                $url = $this->storeManager->getStore($storeId)->getUrl(
                     'koin/request/save',
                     ['_query' => ['hash' => sha1($this->getHash(0) . self::REQUEST_SALT)]]
                 );
+
                 $client = new HttpClient();
                 $client->setUri($url);
                 $client->setMethod(Request::METHOD_POST);

--- a/README.md
+++ b/README.md
@@ -275,3 +275,6 @@ v2.6.1
 
 v2.6.2
 - Feat: Use default private key async requests
+
+v2.6.3
+- Fix: Use hash to async requests

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "koin/payment",
     "description": "Koin Payment Method for Magento 2.3.5+",
     "type": "magento2-module",
-    "version": "2.6.2",
+    "version": "2.6.3",
     "license": [
         "OSL-3.0",
         "AFL-3.0"

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -13,7 +13,7 @@
  */
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Koin_Payment" setup_version="2.6.2">
+    <module name="Koin_Payment" setup_version="2.6.3">
         <sequence>
             <module name="Magento_Sales"/>
             <module name="Magento_Payment"/>


### PR DESCRIPTION
**Title:**
Save request failed to offline transactions

**Description:**
* There was a problem for failed offline refunds wasn't saving response

**Checklist:**
- [x] Changes are consistent with the project's coding style.
- [x] Documentation (if applicable) has been updated.
- [x] Link to related issue (if applicable):

**Testing Instructions:**
* Create an invoice and then create a offline credit memo from the order, not from the invoice
