### PR TITLE
feat: allow fetch info for authorized orders

### DIFF
--- a/Controller/Callback/Payments.php
+++ b/Controller/Callback/Payments.php
@@ -84,9 +84,7 @@ class Payments extends Callback
                     if ($order->getId()) {
                         $method = $order->getPayment()->getMethod();
                         $amount = $this->getCallbackAmount($order, $content);
-                        if ($this->canUpdateOrder($order, $koinStatus)) {
-                            $this->helperOrder->updateOrder($order, $koinStatus, $koinState, $content, $amount, true);
-                        }
+                        $this->helperOrder->updateOrder($order, $koinStatus, $koinState, $content, $amount, true);
                         $statusCode = 204;
                     } elseif ($koinStatus == Api::STATUS_FAILED) {
                         $statusCode = 204;
@@ -108,20 +106,6 @@ class Payments extends Callback
 
         $result->setHttpResponseCode($statusCode);
         return $result;
-    }
-
-    protected function canUpdateOrder($order, $koinStatus): bool
-    {
-        $payment = $order->getPayment();
-        if (
-            $payment->getMethod() == \Koin\Payment\Model\Ui\CreditCard\ConfigProvider::CODE
-            && (bool) $this->helperData->getCcConfig('auto_capture')
-            && $koinStatus == Api::STATUS_COLLECTED
-        ) {
-            return false;
-        }
-
-        return true;
     }
 
     /**

--- a/Gateway/Http/Client/Payments/Api.php
+++ b/Gateway/Http/Client/Payments/Api.php
@@ -36,7 +36,9 @@ class Api
     public const STATUS_REFUNDED = 'Refunded';
     public const STATUS_CANCELLED = 'Cancelled';
     public const STATUS_VOIDED = 'Voided';
+
     public const STATUS_FAILED = 'Failed';
+    public const STATUS_REFUSED = 'ConnectionRefused';
 
     /**
      * @var Data

--- a/Plugin/Adminhtml/Block/FetchInfo.php
+++ b/Plugin/Adminhtml/Block/FetchInfo.php
@@ -43,7 +43,10 @@ class FetchInfo
 
         if (
             $payment->getMethod() == ConfigProvider::CODE
-            && $payment->getAdditionalInformation('status') == Api::STATUS_OPENED
+            && (
+                $payment->getAdditionalInformation('status') == Api::STATUS_OPENED
+                || $payment->getAdditionalInformation('status') == Api::STATUS_AUTHORIZED
+            )
         ) {
             $link = $this->url->getUrl(
                 'koin/order/fetch',

--- a/README.md
+++ b/README.md
@@ -278,3 +278,9 @@ v2.6.2
 
 v2.6.3
 - Fix: Use hash to async requests
+
+v2.6.4
+- Fix: using wrong hash when multi store
+
+v2.6.5
+- Feat: allow fetch info for authorized orders

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "koin/payment",
     "description": "Koin Payment Method for Magento 2.3.5+",
     "type": "magento2-module",
-    "version": "2.6.4",
+    "version": "2.6.5",
     "license": [
         "OSL-3.0",
         "AFL-3.0"

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -13,7 +13,7 @@
  */
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Koin_Payment" setup_version="2.6.4">
+    <module name="Koin_Payment" setup_version="2.6.5">
         <sequence>
             <module name="Magento_Sales"/>
             <module name="Magento_Payment"/>


### PR DESCRIPTION
**Title:**
Feat: allow fetch info for authorized orders
Fix: allow authorized order to update status even with auto capture = true

**Description:**
* Feat: Sometimes the order remained with authorized status and wasn't possible to update the order status
* Fix: The order when a auto capture returns after a successful authorized process, the callback wasn't updating the order

**Checklist:**
- [x] Changes are consistent with the project's coding style.
- [x] Documentation (if applicable) has been updated.
- [x] Link to related issue (if applicable):
