### PR TITLE
Fix error when disabling the payment method logo

### DIFF
--- a/Model/Ui/CreditCard/ConfigProvider.php
+++ b/Model/Ui/CreditCard/ConfigProvider.php
@@ -144,7 +144,7 @@ class ConfigProvider extends CcGenericConfigProvider
             'payment' => [
                 self::CODE => [
                     'grand_total' => $this->checkoutSession->getQuote()->getGrandTotal(),
-                    'show_logo_on_checkout' => $this->helper->getConfig('show_logo_on_checkout', self::CODE),
+                    'show_logo_on_checkout' => (int) $this->helper->getConfig('show_logo_on_checkout', self::CODE),
                     'customer_taxvat' => $customerTaxvat,
                     'icons' => $this->getIcons(),
                     'availableTypes' => $this->getCcAvailableTypes($methodCode)

--- a/Model/Ui/Pix/ConfigProvider.php
+++ b/Model/Ui/Pix/ConfigProvider.php
@@ -119,7 +119,7 @@ class ConfigProvider implements ConfigProviderInterface
                 self::CODE => [
                     'grand_total' => $this->checkoutSession->getQuote()->getGrandTotal(),
                     'checkout_instructions' => trim($this->helper->getConfig('checkout_instructions', self::CODE)),
-                    'show_logo_on_checkout' => $this->helper->getConfig('show_logo_on_checkout', self::CODE),
+                    'show_logo_on_checkout' => (int) $this->helper->getConfig('show_logo_on_checkout', self::CODE),
                     'customer_taxvat' => $customerTaxvat,
                     'koin_logo' => $this->helper->getConfig('logo', self::CODE)
                 ]

--- a/Model/Ui/Redirect/ConfigProvider.php
+++ b/Model/Ui/Redirect/ConfigProvider.php
@@ -104,9 +104,9 @@ class ConfigProvider implements ConfigProviderInterface
             'payment' => [
                 self::CODE => [
                     'grand_total' => $this->checkoutSession->getQuote()->getGrandTotal(),
-                    'use_default_checkout_instructions' =>  $this->helper->getConfig('use_default_checkout_instructions', self::CODE),
-                    'checkout_instructions' =>  $this->helper->getConfig('checkout_instructions', self::CODE),
-                    'show_logo_on_checkout' =>  $this->helper->getConfig('show_logo_on_checkout', self::CODE),
+                    'use_default_checkout_instructions' => $this->helper->getConfig('use_default_checkout_instructions', self::CODE),
+                    'checkout_instructions' => $this->helper->getConfig('checkout_instructions', self::CODE),
+                    'show_logo_on_checkout' => (int) $this->helper->getConfig('show_logo_on_checkout', self::CODE),
                     'customer_taxvat' =>  $customerTaxvat,
                     'checkout_image' => $this->getViewFileUrl('Koin_Payment::images/checkout_description.png')
                 ]

--- a/README.md
+++ b/README.md
@@ -284,3 +284,6 @@ v2.6.4
 
 v2.6.5
 - Feat: allow fetch info for authorized orders
+
+v2.6.6
+- Fix: error disabling logon on checkout

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "koin/payment",
     "description": "Koin Payment Method for Magento 2.3.5+",
     "type": "magento2-module",
-    "version": "2.6.5",
+    "version": "2.6.6",
     "license": [
         "OSL-3.0",
         "AFL-3.0"

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -13,7 +13,7 @@
  */
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Koin_Payment" setup_version="2.6.5">
+    <module name="Koin_Payment" setup_version="2.6.6">
         <sequence>
             <module name="Magento_Sales"/>
             <module name="Magento_Payment"/>


### PR DESCRIPTION
**Title:**
Fix error when disabling the payment method logo

**Description:**
* When the store owner disables the Koin logo on checkout it wasn't hiding it, that way the config wasn't working correcty
*It'll be necessary to create the tag v2.6.6*

**Checklist:**
- [x] Changes are consistent with the project's coding style.
- [x] Documentation (if applicable) has been updated.
- [x] Link to related issue (if applicable):

**Testing Instructions:**
* Change the settings on panel and the Koin logo should behave as expected

![Selection_002](https://github.com/koinlatam/magento2/assets/9461829/9bd6b85c-5184-4706-8cab-8bf5b950fb87)

![Selection_003](https://github.com/koinlatam/magento2/assets/9461829/adbc7814-b48a-4d4b-862c-619e49e31b43)

![Selection_004](https://github.com/koinlatam/magento2/assets/9461829/e2d81470-0e9a-4144-aefa-230bccddec7e)

![Selection_001](https://github.com/koinlatam/magento2/assets/9461829/9ce48509-3f95-412e-b398-fe9a43b83a2f)

