### PR TITLE
Added a lock verification to callbacks

### DIFF
--- a/Controller/Callback/Payments.php
+++ b/Controller/Callback/Payments.php
@@ -16,8 +16,6 @@ use Magento\Sales\Model\Order as SalesOrder;
 
 class Payments extends Callback
 {
-    const LOCK_PREFIX = 'PLACE_ORDER_';
-
     /**
      * @var string
      */
@@ -87,7 +85,7 @@ class Payments extends Callback
                     $koinState = $this->helperOrder->getStatus($koinStatus);
                     $order = $this->helperOrder->loadOrder($transaction['reference_id']);
                     if ($order->getId()) {
-                        if ($this->helperData->isLocked(self::LOCK_PREFIX . $order->getQuoteId())) {
+                        if ($this->helperData->isLocked($order->getQuoteId())) {
                             $message = sprintf('Order %s is locked', $order->getId());
                             $this->helperData->log($message);
                             throw new OrderNotFinishedException(__($message));

--- a/Controller/Callback/Payments.php
+++ b/Controller/Callback/Payments.php
@@ -16,6 +16,8 @@ use Magento\Sales\Model\Order as SalesOrder;
 
 class Payments extends Callback
 {
+    const LOCK_PREFIX = 'PLACE_ORDER_';
+
     /**
      * @var string
      */
@@ -82,6 +84,11 @@ class Payments extends Callback
                     $koinState = $this->helperOrder->getStatus($koinStatus);
                     $order = $this->helperOrder->loadOrder($transaction['reference_id']);
                     if ($order->getId()) {
+                        if ($this->helperData->isLocked(self::LOCK_PREFIX . $order->getQuoteId())) {
+                            $this->helperData->log(sprintf('Order %s is locked', $order->getId()));
+                            sleep(5);
+                        }
+
                         $method = $order->getPayment()->getMethod();
                         $amount = $this->getCallbackAmount($order, $content);
                         $this->helperOrder->updateOrder($order, $koinStatus, $koinState, $content, $amount, true);

--- a/Exception/OrderNotFinishedException.php
+++ b/Exception/OrderNotFinishedException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Koin\Payment\Exception;
+
+use Magento\Framework\Exception\LocalizedException;
+
+class OrderNotFinishedException extends LocalizedException
+{
+
+}

--- a/Gateway/Http/Client/Payments/Api/Refund.php
+++ b/Gateway/Http/Client/Payments/Api/Refund.php
@@ -14,6 +14,7 @@
 namespace Koin\Payment\Gateway\Http\Client\Payments\Api;
 
 use Koin\Payment\Gateway\Http\Client;
+use Koin\Payment\Gateway\Http\Client\Payments\Api;
 use Laminas\Http\Request;
 
 class Refund extends Client
@@ -44,8 +45,32 @@ class Refund extends Client
 
     public function refund($data, $orderId, $storeId): array
     {
+        if (
+            is_object($data) && $data->amount->value == 0
+            || is_array($data) && $data['amount']['value'] == 0
+        ) {
+            return $this->refundEmtpyValue();
+        }
+
         $path = $this->getEndpointPath('payments/refund', $orderId);
         $method = Request::METHOD_PUT;
         return $this->makeRequest($path, $method, $data, $storeId);
+    }
+
+    protected function refundEmtpyValue(): array
+    {
+        return [
+            'status' => 200,
+            'response' => [
+                'refund_id' => '',
+                'message' => 'refund not allowed without amount value',
+                'amount' => [
+                    'value' => 0
+                ],
+                'status' => [
+                    'type' => Api::STATUS_UNKNOWN
+                ]
+            ]
+        ];
     }
 }

--- a/Gateway/Request/RefundRequest.php
+++ b/Gateway/Request/RefundRequest.php
@@ -64,7 +64,7 @@ class RefundRequest implements BuilderInterface
 
         /** @var Order $order */
         $order = $payment->getOrder();
-        $amountValue = $buildSubject['amount'] ?? $order->getGrandTotal();
+        $amountValue = $buildSubject['amount'];
 
         $request = new \stdClass();
         $request->transaction = $this->getTransaction($order);

--- a/Gateway/Response/RefundHandler.php
+++ b/Gateway/Response/RefundHandler.php
@@ -80,9 +80,12 @@ class RefundHandler implements HandlerInterface
             throw new LocalizedException(__('There was an error processing your request.'));
         }
 
-        /** @var \Magento\Sales\Model\Order\Payment $payment */
-        $payment = $paymentData->getPayment();
-        $payment = $this->helperOrder->updateRefundedAdditionalInformation($payment, $transaction);
-        $payment->setAdditionalInformation('refunded', true);
+        $amount = $transaction['amount']['value'];
+        if ($amount > 0) {
+            /** @var \Magento\Sales\Model\Order\Payment $payment */
+            $payment = $paymentData->getPayment();
+            $payment = $this->helperOrder->updateRefundedAdditionalInformation($payment, $transaction);
+            $payment->setAdditionalInformation('refunded', true);
+        }
     }
 }

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -222,13 +222,13 @@ class Data extends \Magento\Payment\Helper\Data
         $message = preg_replace('/"security_code":\s?"([^"]+)"/', '"security_code":"***"', $message);
         $message = preg_replace('/"expiration_month":\s?"([^"]+)"/', '"expiration_month":"**"', $message);
         $message = preg_replace('/"expiration_year":\s?"([^"]+)"/', '"expiration_year":"****"', $message);
-        $message = preg_replace('/"notification_url":\s?\["([^"]+)"\]/', '"notification_url":["*****************"]', $message);
+        $message = preg_replace('/"notification_url":\s?\["([^"]+)"\]/', '"notification_url":["*********"]', $message);
         return preg_replace('/"number":\s?"(\d{6})\d{3,9}(\d{4})"/', '"number":"$1******$2"', $message);
     }
 
     /**
      * @param $message
-     * @return bool|string
+     * @return string
      */
     public function jsonEncode($message): string
     {
@@ -237,7 +237,7 @@ class Data extends \Magento\Payment\Helper\Data
         } catch (\Exception $e) {
             $this->log($e->getMessage());
         }
-        return $message;
+        return (string) $message;
     }
 
     /**

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -26,6 +26,7 @@ use Magento\Framework\App\Helper\Context;
 use Magento\Framework\App\ResourceConnection;
 use Magento\Framework\Component\ComponentRegistrar;
 use Magento\Framework\Filesystem\Io\File;
+use Magento\Framework\Lock\LockManagerInterface;
 use Magento\Framework\Stdlib\DateTime\DateTime;
 use Magento\Framework\UrlInterface;
 use Magento\Framework\View\LayoutFactory;
@@ -118,6 +119,11 @@ class Data extends \Magento\Payment\Helper\Data
      */
     protected $httpClient;
 
+    /**
+     * @var LockManagerInterface
+     */
+    protected $lockManager;
+
     public function __construct(
         Context $context,
         LayoutFactory $layoutFactory,
@@ -140,7 +146,8 @@ class Data extends \Magento\Payment\Helper\Data
         DateTime $dateTime,
         DirectoryData $helperDirectory,
         File $file,
-        HttpClient $httpClient
+        HttpClient $httpClient,
+        LockManagerInterface $lockManager
     ) {
         parent::__construct($context, $layoutFactory, $paymentMethodFactory, $appEmulation, $paymentConfig, $initialConfig);
 
@@ -160,6 +167,7 @@ class Data extends \Magento\Payment\Helper\Data
         $this->helperDirectory = $helperDirectory;
         $this->file = $file;
         $this->httpClient = $httpClient;
+        $this->lockManager = $lockManager;
     }
 
     public function getAllowedMethods(): array
@@ -169,6 +177,11 @@ class Data extends \Magento\Payment\Helper\Data
             \Koin\Payment\Model\Ui\Pix\ConfigProvider::CODE,
             \Koin\Payment\Model\Ui\CreditCard\ConfigProvider::CODE
         ];
+    }
+
+    public function isLocked(string $key): bool
+    {
+        return $this->lockManager->isLocked($key);
     }
 
     public function getFinalStates(): array

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -61,6 +61,10 @@ class Data extends \Magento\Payment\Helper\Data
 
     public const REQUEST_SALT = 'koin_request';
 
+    public const PLACE_ORDER_LOCK_PREFIX = 'PLACE_ORDER_';
+
+    public const CAPTUE_ORDER_LOCK_PREFIX = 'CAPTURE_ORDER_';
+
     /** @var ResourceConnection */
     protected $resourceConnection;
 
@@ -179,9 +183,22 @@ class Data extends \Magento\Payment\Helper\Data
         ];
     }
 
-    public function isLocked(string $key): bool
+    public function lock(string $key, string $prefix = self::CAPTUE_ORDER_LOCK_PREFIX): bool
     {
-        return $this->lockManager->isLocked($key);
+        return $this->lockManager->lock($prefix . $key);
+    }
+
+    public function isLocked(string $key, string $prefix = self::CAPTUE_ORDER_LOCK_PREFIX): bool
+    {
+        return (
+            $this->lockManager->isLocked(self::PLACE_ORDER_LOCK_PREFIX . $key)
+            || $this->lockManager->isLocked($prefix . $key)
+        );
+    }
+
+    public function unlock(string $key, string $prefix = self::CAPTUE_ORDER_LOCK_PREFIX): bool
+    {
+        return $this->lockManager->lock($prefix . $key);
     }
 
     public function getFinalStates(): array
@@ -390,7 +407,7 @@ class Data extends \Magento\Payment\Helper\Data
         return $this->storeManager->getStore($orderId)->getUrl(
             'koin/callback/risk',
             [
-                '_query' => ['hash' => $this->helperData->getHash(0)],
+                '_query' => ['hash' => $this->getHash(0)],
                 '_secure' => true
             ]
         );

--- a/README.md
+++ b/README.md
@@ -287,3 +287,6 @@ v2.6.5
 
 v2.6.6
 - Fix: error disabling logon on checkout
+
+v2.6.7
+- Fix: add lock verification to notification callback

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "koin/payment",
     "description": "Koin Payment Method for Magento 2.3.5+",
     "type": "magento2-module",
-    "version": "2.6.6",
+    "version": "2.6.7",
     "license": [
         "OSL-3.0",
         "AFL-3.0"

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -13,7 +13,7 @@
  */
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Koin_Payment" setup_version="2.6.6">
+    <module name="Koin_Payment" setup_version="2.6.7">
         <sequence>
             <module name="Magento_Sales"/>
             <module name="Magento_Payment"/>


### PR DESCRIPTION
**Title:**
Added a lock verification to callbacks

**Description:**
* When an order was created, sometimes the callback was faster than the invoice and, in that cases it was duplicating invoices

**Checklist:**
- [x] Changes are consistent with the project's coding style.
- [x] Documentation (if applicable) has been updated.
- [x] Link to related issue (if applicable):

**Testing Instructions:**
* It's necessary to create an order with auto capture, and when the server is with a high load, the lock must not allow to duplicate the order