### PR TITLE
Fix: rule title remained even when it changed to a no rule installments

### DIFF
--- a/Observer/CreditCardAssignObserver.php
+++ b/Observer/CreditCardAssignObserver.php
@@ -166,6 +166,8 @@ class CreditCardAssignObserver extends AbstractDataAssignObserver
         $grandTotal = $quote->getGrandTotal() - (float) $quote->getKoinInterestAmount();
 
         $this->setAdditionalInfo($paymentInfo, [
+            'rule_id' => '',
+            'rule_title' => '',
             'rule_data' => '',
             'rule_account_number' => ''
         ]);

--- a/README.md
+++ b/README.md
@@ -294,3 +294,6 @@ v2.6.7
 v2.6.8
 - Fix: Lock is not necessary anymore
 - Feat: added a log when the order pass through the sales_order_save_after event
+
+v2.6.9
+- Fix: error, rule title being shwon if the rule was already on quote

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "koin/payment",
     "description": "Koin Payment Method for Magento 2.3.7+",
     "type": "magento2-module",
-    "version": "2.6.8",
+    "version": "2.6.9",
     "license": [
         "OSL-3.0",
         "AFL-3.0"

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -13,7 +13,7 @@
  */
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Koin_Payment" setup_version="2.6.8">
+    <module name="Koin_Payment" setup_version="2.6.9">
         <sequence>
             <module name="Magento_Sales"/>
             <module name="Magento_Payment"/>


### PR DESCRIPTION
**Title:**
Rule title remained even when it changed to a no rule installments

**Description:**
* In some cases, when the quote has a installments rule selected and the, the rule becomes inactive, the rule title remained  in the quote

**Checklist:**
- [x] Changes are consistent with the project's coding style.
- [x] Documentation (if applicable) has been updated.
- [x] Link to related issue (if applicable):
