### PR TITLE
Fix:  adjust paid config data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,3 +90,6 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Feat: added new settings for auto capture orders
 - Feat: added tuys as a card brand option
 - Fix: Config Status for automatically captured orders
+
+### v2.7.3
+- Fix: Paid config orders was using wrong config

--- a/Helper/Order.php
+++ b/Helper/Order.php
@@ -359,9 +359,10 @@ class Order extends \Magento\Payment\Helper\Data
 
     protected function addPaidComment(OrderInterface $order): OrderInterface
     {
+        $paymentMethod = $order->getPayment()->getMethod();
         $paidStatus = $order->getIsVirtual()
-            ? $this->helperData->getConfig('paid_virtual_order_status')
-            : $this->helperData->getConfig('paid_order_status');
+            ? $this->helperData->getConfig('paid_virtual_order_status', $paymentMethod)
+            : $this->helperData->getConfig('paid_order_status', $paymentMethod);
 
         $message = __('Your payment for the order %1 was confirmed', $order->getIncrementId());
         $order->addCommentToStatusHistory($message, $paidStatus, true);

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "koin/payment",
     "description": "Koin Payment Method for Magento 2.3.7+",
     "type": "magento2-module",
-    "version": "2.7.2",
+    "version": "2.7.3",
     "license": [
         "OSL-3.0",
         "AFL-3.0"

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -13,7 +13,7 @@
  */
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Koin_Payment" setup_version="2.7.2">
+    <module name="Koin_Payment" setup_version="2.7.3">
         <sequence>
             <module name="Magento_Sales"/>
             <module name="Magento_Payment"/>


### PR DESCRIPTION
**Title:**
Fix:  adjust paid config data
*It must create the tag 2.7.3*

**Description:**
There was an error selecting the config for cc payment method, the fallback was koin_redirect and the right config wasn't being called

**Checklist:**
- [x] Changes are consistent with the project's coding style.
- [x] Documentation (if applicable) has been updated.

