### PR TITLE
fix: send postcode with only numbers for BNPL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,4 +99,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Fix: send region code instead of region text for addresses
 
 ### v2.7.5
-- Fix: send region code instead of region text for addresses also for BNPL 
+- Fix: send region code instead of region text for addresses also for BNPL
+
+### v2.7.6
+- Fix: send only number postcode for addresses in BNPL
+- Fix: send number as quantity for transactions

--- a/Gateway/Request/PaymentsRequest.php
+++ b/Gateway/Request/PaymentsRequest.php
@@ -221,7 +221,7 @@ class PaymentsRequest
     {
         $address = new \stdClass();
         $address->country_code = $orderAddress->getCountryId();
-        $address->state = $orderAddress->getRegionCode() ?: $address->getRegion();
+        $address->state = $orderAddress->getRegionCode() ?: $orderAddress->getRegion();
         $address->city_name = $orderAddress->getCity();
         $address->zip_code = $orderAddress->getPostcode();
         $address->street = $orderAddress->getStreetLine($this->getStreetField('street'));
@@ -253,7 +253,7 @@ class PaymentsRequest
             $item->id = $quoteItem->getSku();
             $item->name = $quoteItem->getName();
             $item->price = $this->getPriceItem($quoteItem, $order);
-            $item->quantity = $quoteItem->getQtyOrdered();
+            $item->quantity = (int) $quoteItem->getQtyOrdered();
             $item->discount_amount = $this->getDiscountItem($quoteItem, $order);
             $item->category = $this->getCategoryByQuoteItem($quoteItem);
 

--- a/Gateway/Request/Redirect/TransactionRequest.php
+++ b/Gateway/Request/Redirect/TransactionRequest.php
@@ -116,6 +116,18 @@ class TransactionRequest extends PaymentsRequest implements BuilderInterface
     }
 
     /**
+     * @param \Magento\Sales\Model\Order\Address $orderAddress
+     * @return \stdClass
+     */
+    protected function getAddress($orderAddress): \stdClass
+    {
+        $address = parent::getAddress($orderAddress);
+        $address->zip_code = preg_replace('/\D/', '', $orderAddress->getPostcode());
+
+        return $address;
+    }
+
+    /**
      * @param \Magento\Sales\Model\Order $order
      * @param float $amount
      * @return \stdClass

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "koin/payment",
     "description": "Koin Payment Method for Magento 2.3.7+",
     "type": "magento2-module",
-    "version": "2.7.5",
+    "version": "2.7.6",
     "license": [
         "OSL-3.0",
         "AFL-3.0"

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -13,7 +13,7 @@
  */
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Koin_Payment" setup_version="2.7.5">
+    <module name="Koin_Payment" setup_version="2.7.6">
         <sequence>
             <module name="Magento_Sales"/>
             <module name="Magento_Payment"/>


### PR DESCRIPTION
**Title:**
Send postcode with only numbers for BNPL
Send quantity as int to koin

**Checklist:**
- [x] Changes are consistent with the project's coding style.
- [x] Documentation (if applicable) has been updated.
- [x] Link to related issue (if applicable):
