### PR TITLE
Fix: admin orders with wrong callback URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,3 +104,6 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### v2.7.6
 - Fix: send only number postcode for addresses in BNPL
 - Fix: send number as quantity for transactions
+
+### v2.7.7
+- Fix: callback url for admin onrders 

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -370,10 +370,12 @@ class Data extends \Magento\Payment\Helper\Data
 
     public function getPaymentsNotificationUrl(Order $order): string
     {
-        $orderId = $order->getStoreId() ?: $this->storeManager->getDefaultStoreView()->getId();
-        return $this->storeManager->getStore($orderId)->getUrl(
+        $storeId = $order->getStoreId() ?: $this->storeManager->getDefaultStoreView()->getId();
+        return $this->_urlBuilder->getRouteUrl(
             'koin/callback/payments',
             [
+                '_type' => UrlInterface::URL_TYPE_LINK,
+                '_scope' => $storeId,
                 '_scope_to_url' => true,
                 '_query' => ['hash' => $this->getHash(0)],
                 '_secure' => true
@@ -388,10 +390,12 @@ class Data extends \Magento\Payment\Helper\Data
 
     public function getAntifraudCallbackUrl(Order $order): string
     {
-        $orderId = $order->getStoreId() ?: $this->storeManager->getDefaultStoreView()->getId();
-        return $this->storeManager->getStore($orderId)->getUrl(
+        $storeId = $order->getStoreId() ?: $this->storeManager->getDefaultStoreView()->getId();
+        return $this->_urlBuilder->getRouteUrl(
             'koin/callback/risk',
             [
+                '_type' => UrlInterface::URL_TYPE_LINK,
+                '_scope' => $storeId,
                 '_scope_to_url' => true,
                 '_query' => ['hash' => $this->getHash(0)],
                 '_secure' => true
@@ -401,7 +405,7 @@ class Data extends \Magento\Payment\Helper\Data
 
     public function getReturnUrl(string $incrementId): string
     {
-        return $this->storeManager->getStore()->getUrl(
+        return $this->_urlBuilder->getRouteUrl(
             'koin/success/',
             [
                 '_query' => [

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -301,7 +301,7 @@ class Data extends \Magento\Payment\Helper\Data
     {
         if ($this->getGeneralConfig('debug')) {
             try {
-                $url = $this->_urlBuilder->getUrl(
+                $url = $this->getUrl(
                     'koin/request/save',
                     ['hash' => sha1($this->getHash(0) . self::REQUEST_SALT)]
                 );
@@ -371,12 +371,11 @@ class Data extends \Magento\Payment\Helper\Data
     public function getPaymentsNotificationUrl(Order $order): string
     {
         $storeId = $order->getStoreId() ?: $this->storeManager->getDefaultStoreView()->getId();
-        return $this->_urlBuilder->getUrl(
+        return $this->getUrl(
             'koin/callback/payments',
             [
                 '_type' => UrlInterface::URL_TYPE_LINK,
                 '_scope' => $storeId,
-                '_scope_to_url' => true,
                 '_query' => ['hash' => $this->getHash(0)],
                 '_secure' => true
             ]
@@ -391,12 +390,11 @@ class Data extends \Magento\Payment\Helper\Data
     public function getAntifraudCallbackUrl(Order $order): string
     {
         $storeId = $order->getStoreId() ?: $this->storeManager->getDefaultStoreView()->getId();
-        return $this->_urlBuilder->getUrl(
+        return $this->getUrl(
             'koin/callback/risk',
             [
                 '_type' => UrlInterface::URL_TYPE_LINK,
                 '_scope' => $storeId,
-                '_scope_to_url' => true,
                 '_query' => ['hash' => $this->getHash(0)],
                 '_secure' => true
             ]

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -301,7 +301,7 @@ class Data extends \Magento\Payment\Helper\Data
     {
         if ($this->getGeneralConfig('debug')) {
             try {
-                $url = $this->_urlBuilder->getRouteUrl(
+                $url = $this->_urlBuilder->getUrl(
                     'koin/request/save',
                     ['hash' => sha1($this->getHash(0) . self::REQUEST_SALT)]
                 );
@@ -371,7 +371,7 @@ class Data extends \Magento\Payment\Helper\Data
     public function getPaymentsNotificationUrl(Order $order): string
     {
         $storeId = $order->getStoreId() ?: $this->storeManager->getDefaultStoreView()->getId();
-        return $this->_urlBuilder->getRouteUrl(
+        return $this->_urlBuilder->getUrl(
             'koin/callback/payments',
             [
                 '_type' => UrlInterface::URL_TYPE_LINK,
@@ -391,7 +391,7 @@ class Data extends \Magento\Payment\Helper\Data
     public function getAntifraudCallbackUrl(Order $order): string
     {
         $storeId = $order->getStoreId() ?: $this->storeManager->getDefaultStoreView()->getId();
-        return $this->_urlBuilder->getRouteUrl(
+        return $this->_urlBuilder->getUrl(
             'koin/callback/risk',
             [
                 '_type' => UrlInterface::URL_TYPE_LINK,

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -224,7 +224,7 @@ class Data extends \Magento\Payment\Helper\Data
         $message = preg_replace('/"security_code":\s?"([^"]+)"/', '"security_code":"***"', $message);
         $message = preg_replace('/"expiration_month":\s?"([^"]+)"/', '"expiration_month":"**"', $message);
         $message = preg_replace('/"expiration_year":\s?"([^"]+)"/', '"expiration_year":"****"', $message);
-        $message = preg_replace('/"notification_url":\s?\["([^"]+)"\]/', '"notification_url":["*********"]', $message);
+        $message = preg_replace('/(hash=)[^&"]+/', 'hash=******', $message);
         return preg_replace('/"number":\s?"(\d{6})\d{3,9}(\d{4})"/', '"number":"$1******$2"', $message);
     }
 

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -130,6 +130,11 @@ class Data extends \Magento\Payment\Helper\Data
      */
     protected $lockManager;
 
+    /**
+     * @var UrlInterface
+     */
+    protected $urlHelper;
+
     public function __construct(
         Context $context,
         LayoutFactory $layoutFactory,
@@ -153,7 +158,8 @@ class Data extends \Magento\Payment\Helper\Data
         DirectoryData $helperDirectory,
         File $file,
         HttpClient $httpClient,
-        LockManagerInterface $lockManager
+        LockManagerInterface $lockManager,
+        UrlInterface $urlHelper
     ) {
         parent::__construct($context, $layoutFactory, $paymentMethodFactory, $appEmulation, $paymentConfig, $initialConfig);
 
@@ -174,6 +180,7 @@ class Data extends \Magento\Payment\Helper\Data
         $this->file = $file;
         $this->httpClient = $httpClient;
         $this->lockManager = $lockManager;
+        $this->urlHelper = $urlHelper;
     }
 
     public function getAllowedMethods(): array
@@ -370,14 +377,13 @@ class Data extends \Magento\Payment\Helper\Data
 
     public function getPaymentsNotificationUrl(Order $order): string
     {
-        $orderId = $order->getStoreId() ?: $this->storeManager->getDefaultStoreView()->getId();
-        return $this->storeManager->getStore($orderId)->getUrl(
-            'koin/callback/payments',
-            [
-                '_query' => ['hash' => $this->getHash(0)],
-                '_secure' => true
-            ]
-        );
+        $storeId = $order->getStoreId() ?: $this->storeManager->getDefaultStoreView()->getId();
+        return $this->urlHelper->getUrl( 'koin/callback/payments', [
+            '_scope' => $storeId,
+            '_query' => ['hash' => $this->getHash(0)],
+            '_secure' => true,
+            '_nosid' => true
+        ]);
     }
 
     public function getHash($scopeCode = null): string

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -223,7 +223,7 @@ class Data extends \Magento\Payment\Helper\Data
         $message = preg_replace('/"security_code":\s?"([^"]+)"/', '"security_code":"***"', $message);
         $message = preg_replace('/"expiration_month":\s?"([^"]+)"/', '"expiration_month":"**"', $message);
         $message = preg_replace('/"expiration_year":\s?"([^"]+)"/', '"expiration_year":"****"', $message);
-        $message = preg_replace('/"notification_url":\s?\["([^"]+)"\]/', '"notification_url":["*********"]', $message);
+        $message = preg_replace('/(hash=)[^&"]+/', 'hash=******', $message);
         return preg_replace('/"number":\s?"(\d{6})\d{3,9}(\d{4})"/', '"number":"$1******$2"', $message);
     }
 

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -21,7 +21,6 @@ use Laminas\Http\Client as HttpClient;
 use Laminas\Http\Request;
 use Magento\Catalog\Api\CategoryRepositoryInterface;
 use Magento\Directory\Helper\Data as DirectoryData;
-use Magento\Framework\App\Area;
 use Magento\Framework\App\Config\Initial;
 use Magento\Framework\App\Helper\Context;
 use Magento\Framework\App\ResourceConnection;
@@ -224,7 +223,7 @@ class Data extends \Magento\Payment\Helper\Data
         $message = preg_replace('/"security_code":\s?"([^"]+)"/', '"security_code":"***"', $message);
         $message = preg_replace('/"expiration_month":\s?"([^"]+)"/', '"expiration_month":"**"', $message);
         $message = preg_replace('/"expiration_year":\s?"([^"]+)"/', '"expiration_year":"****"', $message);
-        $message = preg_replace('/(hash=)[^&"]+/', 'hash=******', $message);
+        $message = preg_replace('/"notification_url":\s?\["([^"]+)"\]/', '"notification_url":["*********"]', $message);
         return preg_replace('/"number":\s?"(\d{6})\d{3,9}(\d{4})"/', '"number":"$1******$2"', $message);
     }
 
@@ -371,20 +370,15 @@ class Data extends \Magento\Payment\Helper\Data
 
     public function getPaymentsNotificationUrl(Order $order): string
     {
-        $storeId = $order->getStoreId() ?: $this->storeManager->getDefaultStoreView()->getId();
-        $this->_appEmulation->startEnvironmentEmulation($storeId, Area::AREA_FRONTEND, true);
-
-        $notificationUrl = $this->storeManager->getStore($storeId)->getUrl(
+        $orderId = $order->getStoreId() ?: $this->storeManager->getDefaultStoreView()->getId();
+        return $this->storeManager->getStore($orderId)->getUrl(
             'koin/callback/payments',
             [
+                '_scope_to_url' => true,
                 '_query' => ['hash' => $this->getHash(0)],
                 '_secure' => true
             ]
         );
-
-        $this->_appEmulation->stopEnvironmentEmulation();
-
-        return $notificationUrl;
     }
 
     public function getHash($scopeCode = null): string
@@ -394,19 +388,15 @@ class Data extends \Magento\Payment\Helper\Data
 
     public function getAntifraudCallbackUrl(Order $order): string
     {
-        $storeId = $order->getStoreId() ?: $this->storeManager->getDefaultStoreView()->getId();
-
-        $this->_appEmulation->startEnvironmentEmulation($storeId, Area::AREA_FRONTEND, true);
-        $notificationUrl = $this->storeManager->getStore($storeId)->getUrl(
+        $orderId = $order->getStoreId() ?: $this->storeManager->getDefaultStoreView()->getId();
+        return $this->storeManager->getStore($orderId)->getUrl(
             'koin/callback/risk',
             [
+                '_scope_to_url' => true,
                 '_query' => ['hash' => $this->getHash(0)],
                 '_secure' => true
             ]
         );
-        $this->_appEmulation->stopEnvironmentEmulation();
-
-        return $notificationUrl;
     }
 
     public function getReturnUrl(string $incrementId): string

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "koin/payment",
     "description": "Koin Payment Method for Magento 2.3.7+",
     "type": "magento2-module",
-    "version": "2.7.6",
+    "version": "2.7.7",
     "license": [
         "OSL-3.0",
         "AFL-3.0"

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -13,7 +13,7 @@
  */
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Koin_Payment" setup_version="2.7.6">
+    <module name="Koin_Payment" setup_version="2.7.7">
         <sequence>
             <module name="Magento_Sales"/>
             <module name="Magento_Payment"/>


### PR DESCRIPTION
**Title:**
Admin orders with wrong callback URL

**Description:**
It was changed the way the URL is created to work both with admin orders and frontend orders
Only the getURL method was changed

**Checklist:**
- [x] Changes are consistent with the project's coding style.
- [x] Documentation (if applicable) has been updated.
- [x] Link to related issue (if applicable):

